### PR TITLE
feat: DAD channel-first MVP (lobby buttons, /support, /help)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ A comprehensive multiplayer party game platform featuring Discord authentication
 - 🚀 [Deployment with Integrations](DEPLOYMENT_INTEGRATIONS.md) - Deploy with optional integrations
 - 📱 [Discord Activities Analysis](DISCORD_ACTIVITIES.md) - Why Discord Activities aren't currently implemented
 
+## 📢 Channel MVP (current)
+
+The Discord bot now runs entirely in-channel — no web arena or Activity required to play.
+
+- **How to play**: Run `/create-game` in any channel (type defaults to Degens Against Decency). A lobby embed appears with **Join / Leave / Start** buttons — no need to type IDs or open a separate view.
+- **`/help`** — Posts a quick guide on how to play in the current channel.
+- **`/support`** — Send the dev team a bug report, suggestion, a friendly hello, or a tip-jar link. Reports route to an internal ops/support channel.
+- **Lobbies are in-memory** — they live only as long as the bot process. A Fly.io restart or redeploy clears any open lobbies; players will need to `/create-game` again.
+- **Discord Activity `/launch`** — The Activity's Primary Entry Point command is preserved during deploys (so Discord doesn't reject the registration), but the Activity itself is product-parked in favor of the simpler channel flow above.
+
 ## 🎯 Features
 
 ### 🔐 Discord OAuth Authentication

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -29,7 +29,7 @@ function buildCommands() {
       .setName('create-game')
       .setDescription('Create a new Discord game')
       .addStringOption((opt) =>
-        opt.setName('type').setDescription('Game type').setRequired(true).addChoices(
+        opt.setName('type').setDescription('Game type (defaults to Degens Against Decency)').setRequired(false).addChoices(
           { name: 'Degens Against Decency', value: 'degens-against-decency' },
           { name: '2 Truths and a Lie', value: '2-truths-and-a-lie' },
           { name: 'Poker', value: 'poker' },
@@ -59,6 +59,23 @@ function buildCommands() {
     new SlashCommandBuilder()
       .setName('game-status')
       .setDescription('Check your current game status'),
+    new SlashCommandBuilder()
+      .setName('support')
+      .setDescription('Contact the DAD team — bug, suggestion, say hi, or tip jar')
+      .addStringOption((opt) =>
+        opt.setName('type').setDescription('What kind of message?').setRequired(true).addChoices(
+          { name: '🐛 Bug report', value: 'bug_report' },
+          { name: '💡 Suggestion', value: 'suggestion' },
+          { name: '👋 Say hi to the dev', value: 'say_hi' },
+          { name: '☕ Donation / tip jar', value: 'donate' },
+        ),
+      )
+      .addStringOption((opt) =>
+        opt.setName('details').setDescription('Details (required for bugs/suggestions)').setRequired(false),
+      ),
+    new SlashCommandBuilder()
+      .setName('help')
+      .setDescription('How to play Degens Against Decency in this channel'),
   ].map((cmd) => cmd.toJSON());
 }
 

--- a/docs/superpowers/plans/2026-07-12-dad-channel-first-mvp.md
+++ b/docs/superpowers/plans/2026-07-12-dad-channel-first-mvp.md
@@ -1,0 +1,209 @@
+# DAD Channel-First MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Degens Against Decency playable as a channel-first bot (button lobby + `/support` + `/help`), hide Activity/Poker/2T from the primary path, and close ops gaps for a 2-week PMF experiment.
+
+**Architecture:** Extend `DiscordBot.js` with button `customId` routing and new slash handlers; extend `ops.js` with `postSupport` / `postGameEnded`; update `deploy-commands.js` to register `/support` and `/help` while preserving Entry Point type 4. Keep fallback ID commands. No Activity SDK work. No new DB (document in-memory restart limit).
+
+**Tech Stack:** Node.js, discord.js v14, existing Fly app `degensagainstdecency`, shared OPS_* channels.
+
+**Spec:** `docs/superpowers/specs/2026-07-12-dad-channel-first-design.md`
+
+**Working directory:** `DegensAgainstDecency/` (TiltCheck-ME/DegensAgainstDecency)
+
+**Reference:** Royale lobby buttons + `/support` in `rumble2.0/bot/bot.js` and `rumble2.0/bot/ops.js` (copy patterns, do not import across repos).
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `src/ops.js` | Add `postSupport`, `postGameEnded`; export them |
+| `src/DiscordBot.js` | Lobby buttons, button handlers, create-game UX, support/help handlers, DAD-default type |
+| `deploy-commands.js` | Register `/support`, `/help`; keep existing + Entry Point preserve |
+| `README.md` | Document Fly restart limitation + channel how-to |
+
+---
+
+### Task 1: Ops — `postSupport` + `postGameEnded`
+
+**Files:**
+- Modify: `src/ops.js`
+
+- [ ] **Step 1: Add `postSupport` to `src/ops.js`**
+
+After `postAnalytics`, add (footer bot id via `botId()`):
+
+```javascript
+function postSupport({ type, user, guild, details }) {
+  const typeLabel = {
+    bug_report: '🐛 Bug report',
+    suggestion: '💡 Suggestion',
+    say_hi: '👋 Say hi',
+    donate: '☕ Donate',
+  }[type] || type;
+
+  postOps('support', () => ({
+    embeds: [
+      new EmbedBuilder()
+        .setColor(COLORS.support)
+        .setTitle(typeLabel)
+        .setDescription(details ? truncate(details, 1500) : '_No details_')
+        .addFields(
+          { name: 'User', value: `${user?.tag || '?'} (<@${user?.id}>)`, inline: true },
+          { name: 'Guild', value: guild ? `${guild.name}\n\`${guild.id}\`` : 'DM / unknown', inline: true },
+        )
+        .setFooter({ text: `${botId()} · /support` })
+        .setTimestamp(),
+    ],
+  }));
+}
+```
+
+- [ ] **Step 2: Add `postGameEnded`**
+
+```javascript
+function postGameEnded({ guildId, channelId, gameType, winnerTag, players }) {
+  postAnalytics({
+    event: 'game_ended',
+    title: '🏆 Game ended',
+    fields: [
+      { name: 'Type', value: gameType || '?', inline: true },
+      { name: 'Winner', value: winnerTag || '?', inline: true },
+      { name: 'Players', value: String(players ?? '?'), inline: true },
+      { name: 'Guild', value: `\`${guildId || '?'}\``, inline: true },
+      channelId ? { name: 'Channel', value: `<#${channelId}>`, inline: true } : null,
+    ],
+  });
+}
+```
+
+- [ ] **Step 3: Export both from `module.exports`**
+
+Include `postSupport` and `postGameEnded` alongside existing exports.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ops.js
+git commit -m "feat: add DAD ops postSupport and postGameEnded"
+```
+
+---
+
+### Task 2: Lobby embed + Join/Leave/Start buttons (no Activity CTA)
+
+**Files:**
+- Modify: `src/DiscordBot.js`
+
+- [ ] **Step 1: Add helpers** (`lobbyCustomId`, `parseLobbyCustomId`, `buildLobbyComponents`, `buildLobbyEmbed`) as specified in the design — Join/Leave/Start buttons with `dad_join:`, `dad_leave:`, `dad_start:` customIds; embed shows roster without Activity link.
+
+- [ ] **Step 2: Rewrite `createDiscordGame` reply path**
+
+1. Remove Activity `Link` button (`Open Retro View`).
+2. Reply with lobby embed + `buildLobbyComponents`.
+3. Store `lobbyMessageId` from the reply.
+4. Do not post ID/reaction-primary follow-up; skip `react('🎮')`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/DiscordBot.js
+git commit -m "feat: channel lobby embed with Join Leave Start buttons"
+```
+
+---
+
+### Task 3: Button handlers + create-game DAD default
+
+**Files:**
+- Modify: `src/DiscordBot.js`
+
+- [ ] **Step 1: Expand `interactionCreate`** to handle `interaction.isButton()` via `handleLobbyButton` before slash commands; keep `postError` on failures.
+
+- [ ] **Step 2: Implement `handleLobbyButton` + `refreshLobbyMessage`**
+
+- join: add user if waiting and not full  
+- leave: non-host remove  
+- start: host-only, min 3 players, `postGameStarted`, call `startDegensDiscordGame`  
+- Wire `postGameEnded` where Degens finishes (`status = 'finished'` / winner announce)
+
+- [ ] **Step 3: Make create-game `type` optional**; default `'degens-against-decency'`; if poker/2-truths selected, ephemeral “Deferred for MVP”.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/DiscordBot.js
+git commit -m "feat: handle lobby buttons and default create-game to Degens"
+```
+
+---
+
+### Task 4: `/support` + `/help` handlers
+
+**Files:**
+- Modify: `src/DiscordBot.js`
+
+- [ ] **Step 1: Add SlashCommandBuilders** for `support` (type + details, Royale choices) and `help`; register in `this.commands`.
+
+- [ ] **Step 2: Implement `handleHelp` and `handleSupport`** using `postSupport` from ops; donate uses `KOFI_URL` or default Ko-fi.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/DiscordBot.js
+git commit -m "feat: add /support and /help for DAD channel MVP"
+```
+
+---
+
+### Task 5: Deploy commands + Fly + smoke
+
+**Files:**
+- Modify: `deploy-commands.js`
+- Modify: `README.md`
+
+- [ ] **Step 1: Update `buildCommands()`** to include `/support` and `/help`; make create-game `type` optional; keep Entry Point preserve.
+
+- [ ] **Step 2: README** — channel MVP how-to + in-memory restart note + Activity parked.
+
+- [ ] **Step 3: Register + deploy**
+
+```bash
+npm run deploy-commands
+git push origin HEAD
+flyctl deploy -a degensagainstdecency --ha=false
+curl -s https://degensagainstdecency.fly.dev/api/health
+```
+
+- [ ] **Step 4: Manual smoke** — `/help`, `/create-game` (no Retro View), Join button, `/support` → ops channel.
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+git add deploy-commands.js README.md
+git commit -m "feat: register /support /help and document channel MVP"
+git push origin HEAD
+```
+
+---
+
+## Spec coverage
+
+| Spec item | Task |
+|-----------|------|
+| Channel-first / Activity parked | Tasks 2–3 |
+| Lobby buttons | Tasks 2–3 |
+| `/support` + ops | Tasks 1, 4, 5 |
+| `/help` | Tasks 4–5 |
+| DAD-only default | Task 3 |
+| `postGameEnded` | Tasks 1, 3 |
+| Preserve Entry Point | Task 5 |
+| Restart note | Task 5 |
+| Fallback ID commands | Keep (no deletion) |
+
+## Out of scope
+
+- Activity SDK polish, ephemeral card UI, DB persistence, `/dad` rename, mass announcements

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -222,6 +222,56 @@ class DiscordBot {
     return buildChannelGamesMap(this.discordGames);
   }
 
+  lobbyCustomId(action, gameId) {
+    return `dad_${action}:${gameId}`;
+  }
+
+  parseLobbyCustomId(customId) {
+    const m = /^dad_(join|leave|start):(.+)$/.exec(customId || '');
+    if (!m) return null;
+    return { action: m[1], gameId: m[2] };
+  }
+
+  buildLobbyComponents(game, { disabled = false } = {}) {
+    const row = new ActionRowBuilder().addComponents(
+      new ButtonBuilder()
+        .setCustomId(this.lobbyCustomId('join', game.id))
+        .setLabel('Join')
+        .setStyle(ButtonStyle.Success)
+        .setDisabled(disabled || game.status !== 'waiting'),
+      new ButtonBuilder()
+        .setCustomId(this.lobbyCustomId('leave', game.id))
+        .setLabel('Leave')
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(disabled || game.status !== 'waiting'),
+      new ButtonBuilder()
+        .setCustomId(this.lobbyCustomId('start', game.id))
+        .setLabel('Start')
+        .setStyle(ButtonStyle.Danger)
+        .setDisabled(disabled || game.status !== 'waiting'),
+    );
+    return [row];
+  }
+
+  buildLobbyEmbed(game) {
+    const roster = game.players.length
+      ? game.players.map((p, i) => `${i === 0 ? '👑' : '•'} ${p.username || p.tag || p.id}`).join('\n')
+      : '*No players yet*';
+
+    return new EmbedBuilder()
+      .setColor(0x5865F2)
+      .setTitle('🎮 Lobby open')
+      .setDescription(`${this.formatGameType(game.type)} — waiting for players`)
+      .addFields(
+        { name: 'Game ID', value: `\`${game.id}\``, inline: true },
+        { name: 'Players', value: `${game.players.length}/${game.maxPlayers}`, inline: true },
+        { name: 'Host', value: game.creator?.username || '?', inline: true },
+        { name: `Roster`, value: roster },
+      )
+      .setFooter({ text: 'Use Join / Leave / Start • ID commands still work as fallback' })
+      .setTimestamp();
+  }
+
   // Command Handlers
   async handleCreateGame(interaction) {
     const gameType = interaction.options.getString('type');
@@ -272,48 +322,13 @@ class DiscordBot {
 
     this.discordGames.set(gameId, discordGame);
 
-    const embed = new EmbedBuilder()
-      .setColor(0x5865F2)
-      .setTitle('🎮 Game Created!')
-      .setDescription(`${this.formatGameType(gameType)} game is ready to play!`)
-      .addFields(
-        { name: 'Game ID', value: gameId, inline: true },
-        { name: 'Players', value: `1/${maxPlayers}`, inline: true },
-        { name: 'Status', value: '⏳ Waiting for players', inline: true }
-      )
-      .setFooter({ text: 'Other players can join with /join-game' })
-      .setTimestamp();
+    const reply = await interaction.reply({
+      embeds: [this.buildLobbyEmbed(discordGame)],
+      components: this.buildLobbyComponents(discordGame),
+      fetchReply: true,
+    });
 
-    const activityRow = new ActionRowBuilder().addComponents(
-      new ButtonBuilder()
-        .setLabel('🖥️ Open Retro View')
-        .setStyle(ButtonStyle.Link)
-        .setURL(this.activityUrl(interaction.channelId)),
-    );
-
-    await interaction.reply({ embeds: [embed], components: [activityRow] });
-
-    // Send follow-up instructions
-    const instructionsEmbed = new EmbedBuilder()
-      .setColor(0x57F287)
-      .setTitle('🎯 How to Join')
-      .setDescription('Players can join this game using:')
-      .addFields(
-        { name: 'Command', value: `/join-game ${gameId}`, inline: false },
-        { name: 'Or React', value: 'React with 🎮 to join!', inline: false }
-      );
-
-    const followUp = await interaction.followUp({ embeds: [instructionsEmbed] });
-    
-    // Add reaction for easy joining
-    try {
-      await followUp.react('🎮');
-    } catch (error) {
-      console.error('Failed to add reaction:', error);
-    }
-
-    // Store message ID for reaction handling
-    discordGame.joinMessageId = followUp.id;
+    discordGame.lobbyMessageId = reply.id;
     this.emitSpectator(interaction.channelId, 'snapshot', discordGame);
   }
 

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -318,6 +318,7 @@ class DiscordBot {
         await interaction.reply({ content: '❌ Lobby is full.', ephemeral: true });
         return;
       }
+      await interaction.deferReply({ ephemeral: true });
       game.players.push({
         id: interaction.user.id,
         username: interaction.user.username,
@@ -327,7 +328,7 @@ class DiscordBot {
       });
       await this.refreshLobbyMessage(game);
       this.emitSpectator(game.channelId, 'lobby_update', game);
-      await interaction.reply({ content: `✅ Joined lobby \`${game.id}\`.`, ephemeral: true });
+      await interaction.editReply({ content: `✅ Joined lobby \`${game.id}\`.` });
       return;
     }
 
@@ -340,15 +341,15 @@ class DiscordBot {
         await interaction.reply({ content: '❌ Host cannot leave. Start the game or abandon by creating a new one.', ephemeral: true });
         return;
       }
-      const before = game.players.length;
-      game.players = game.players.filter((p) => p.id !== interaction.user.id);
-      if (game.players.length === before) {
+      if (!game.players.some((p) => p.id === interaction.user.id)) {
         await interaction.reply({ content: 'You are not in this lobby.', ephemeral: true });
         return;
       }
+      await interaction.deferReply({ ephemeral: true });
+      game.players = game.players.filter((p) => p.id !== interaction.user.id);
       await this.refreshLobbyMessage(game);
       this.emitSpectator(game.channelId, 'lobby_update', game);
-      await interaction.reply({ content: '👋 Left the lobby.', ephemeral: true });
+      await interaction.editReply({ content: '👋 Left the lobby.' });
       return;
     }
 
@@ -366,6 +367,7 @@ class DiscordBot {
         return;
       }
 
+      await interaction.deferReply();
       game.status = 'playing';
       game.currentRound = 1;
       await this.refreshLobbyMessage(game);
@@ -380,7 +382,7 @@ class DiscordBot {
         )
         .setTimestamp();
 
-      await interaction.reply({ embeds: [embed] });
+      await interaction.editReply({ embeds: [embed] });
       this.emitSpectator(game.channelId, 'game_start', game);
       postGameStarted({
         guildId: interaction.guildId || game.guildId,
@@ -650,6 +652,7 @@ class DiscordBot {
     // Start the game
     game.status = 'playing';
     game.currentRound = 1;
+    await this.refreshLobbyMessage(game);
 
     const embed = new EmbedBuilder()
       .setColor(0x00FF00)

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -17,7 +17,7 @@ const {
   ButtonStyle,
 } = require('discord.js');
 const { serializeGameForSpectator, buildChannelGamesMap } = require('./spectator');
-const { initOps, postError, postGuildInstall, postGameStarted, postGameEnded } = require('./ops');
+const { initOps, postError, postGuildInstall, postGameStarted, postGameEnded, postSupport } = require('./ops');
 
 class DiscordBot {
   constructor(gameManager, io, options = {}) {
@@ -107,6 +107,32 @@ class DiscordBot {
       .setName('game-status')
       .setDescription('Check your current game status');
 
+    const supportCommand = new SlashCommandBuilder()
+      .setName('support')
+      .setDescription('Contact the DAD team — bug, suggestion, say hi, or tip jar')
+      .addStringOption((option) =>
+        option
+          .setName('type')
+          .setDescription('What kind of message?')
+          .setRequired(true)
+          .addChoices(
+            { name: '🐛 Bug report', value: 'bug_report' },
+            { name: '💡 Suggestion', value: 'suggestion' },
+            { name: '👋 Say hi to the dev', value: 'say_hi' },
+            { name: '☕ Donation / tip jar', value: 'donate' },
+          ),
+      )
+      .addStringOption((option) =>
+        option
+          .setName('details')
+          .setDescription('Details (required for bugs/suggestions)')
+          .setRequired(false),
+      );
+
+    const helpCommand = new SlashCommandBuilder()
+      .setName('help')
+      .setDescription('How to play Degens Against Decency in this channel');
+
     this.commands.set('create-game', {
       data: createGameCommand,
       execute: this.handleCreateGame.bind(this)
@@ -131,6 +157,9 @@ class DiscordBot {
       data: gameStatusCommand,
       execute: this.handleGameStatus.bind(this)
     });
+
+    this.commands.set('support', { data: supportCommand, execute: this.handleSupport.bind(this) });
+    this.commands.set('help', { data: helpCommand, execute: this.handleHelp.bind(this) });
   }
 
   setupEventHandlers() {
@@ -1735,6 +1764,93 @@ class DiscordBot {
     }
 
     this.emitSpectator(targetGame.channelId, 'lobby_update', targetGame);
+  }
+
+  async handleHelp(interaction) {
+    const embed = new EmbedBuilder()
+      .setColor(0x5865F2)
+      .setTitle('🃏 Degens Against Decency — Channel play')
+      .setDescription(
+        [
+          '**1.** `/create-game` — open a lobby (defaults to Degens)',
+          '**2.** Press **Join** on the lobby message',
+          '**3.** Host presses **Start** (need 3+ players)',
+          '**4.** Play in this channel — follow bot prompts',
+          '',
+          'Fallbacks: `/join-game`, `/list-games`, `/start-game`, `/game-status`',
+          'Need us? `/support`',
+          '',
+          '_Lobbies are in-memory — a bot restart clears open games._',
+        ].join('\n'),
+      )
+      .setFooter({ text: 'Activity /launch is parked — channel play is the MVP path' })
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+  }
+
+  async handleSupport(interaction) {
+    const type = interaction.options.getString('type', true);
+    const details = interaction.options.getString('details')?.trim() || '';
+    const kofiUrl = (process.env.KOFI_URL || 'https://ko-fi.com/jmenichole0').trim();
+
+    if (type === 'donate') {
+      await interaction.deferReply({ ephemeral: true });
+      postSupport({
+        type: 'donate',
+        user: interaction.user,
+        guild: interaction.guild,
+        details: 'Requested Ko-fi DM',
+      });
+      const donateEmbed = new EmbedBuilder()
+        .setColor(0xf1c40f)
+        .setTitle('☕ Tip jar')
+        .setDescription(`Optional tip — zero gameplay perks.\n\n→ [**Support on Ko-fi**](${kofiUrl})`)
+        .setTimestamp();
+      try {
+        await interaction.user.send({ embeds: [donateEmbed] });
+        await interaction.editReply({ content: '✅ Sent the Ko-fi link to your DMs!' });
+      } catch {
+        await interaction.editReply({
+          content: "⚠️ Couldn't DM you — privacy settings may block bot DMs. Here's the link:",
+          embeds: [donateEmbed],
+        });
+      }
+      return;
+    }
+
+    await interaction.deferReply({ ephemeral: true });
+
+    if (type === 'say_hi') {
+      const note = details || '(waved from the channel)';
+      postSupport({ type: 'say_hi', user: interaction.user, guild: interaction.guild, details: note });
+      await interaction.editReply({
+        content:
+          `👋 **Hey, ${interaction.user.username}!**\n` +
+          'Thanks for saying hi — the team sees you.\n\n' +
+          (details ? `_You said: ${details}_` : '_Keep dealing those cards._'),
+      });
+      return;
+    }
+
+    if (type === 'bug_report' || type === 'suggestion') {
+      if (!details) {
+        await interaction.editReply({
+          content: `Please include \`details\` for ${type === 'bug_report' ? 'bug reports' : 'suggestions'}.`,
+        });
+        return;
+      }
+      postSupport({ type, user: interaction.user, guild: interaction.guild, details });
+      await interaction.editReply({
+        content:
+          type === 'bug_report'
+            ? '🐛 Got it — bug report filed. Thanks for helping us fix things.'
+            : '💡 Suggestion received. Appreciate you!',
+      });
+      return;
+    }
+
+    await interaction.editReply({ content: 'Unknown support type.' });
   }
 
   async handleGameStatus(interaction) {

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -17,7 +17,7 @@ const {
   ButtonStyle,
 } = require('discord.js');
 const { serializeGameForSpectator, buildChannelGamesMap } = require('./spectator');
-const { initOps, postError, postGuildInstall, postGameStarted } = require('./ops');
+const { initOps, postError, postGuildInstall, postGameStarted, postGameEnded } = require('./ops');
 
 class DiscordBot {
   constructor(gameManager, io, options = {}) {
@@ -58,8 +58,8 @@ class DiscordBot {
       .setDescription('Create a new Discord game')
       .addStringOption(option =>
         option.setName('type')
-          .setDescription('Game type')
-          .setRequired(true)
+          .setDescription('Game type (defaults to Degens Against Decency)')
+          .setRequired(false)
           .addChoices(
             { name: 'Degens Against Decency', value: 'degens-against-decency' },
             { name: '2 Truths and a Lie', value: '2-truths-and-a-lie' },
@@ -146,22 +146,32 @@ class DiscordBot {
     });
 
     this.client.on('interactionCreate', async (interaction) => {
-      if (!interaction.isChatInputCommand()) return;
-
-      const command = this.commands.get(interaction.commandName);
-      if (!command) return;
-
       try {
+        if (interaction.isButton()) {
+          const parsed = this.parseLobbyCustomId(interaction.customId);
+          if (parsed) {
+            await this.handleLobbyButton(interaction, parsed);
+          }
+          return;
+        }
+
+        if (!interaction.isChatInputCommand()) return;
+
+        const command = this.commands.get(interaction.commandName);
+        if (!command) return;
+
         await command.execute(interaction);
       } catch (error) {
-        console.error('Error executing command:', error);
+        console.error('Error handling interaction:', error);
         postError({
-          context: `interaction:${interaction.commandName}`,
+          context: interaction.isChatInputCommand()
+            ? `interaction:${interaction.commandName}`
+            : `interaction:button:${interaction.customId || 'unknown'}`,
           message: error.message || String(error),
           stack: error.stack,
         });
         const reply = { content: 'There was an error executing this command!', ephemeral: true };
-        
+
         if (interaction.replied || interaction.deferred) {
           await interaction.followUp(reply).catch(() => {});
         } else {
@@ -272,9 +282,135 @@ class DiscordBot {
       .setTimestamp();
   }
 
+  async refreshLobbyMessage(game) {
+    if (!game?.lobbyMessageId || !game.channelId) return;
+    try {
+      const channel = await this.client.channels.fetch(game.channelId);
+      const message = await channel.messages.fetch(game.lobbyMessageId);
+      const disabled = game.status !== 'waiting';
+      await message.edit({
+        embeds: [this.buildLobbyEmbed(game)],
+        components: this.buildLobbyComponents(game, { disabled }),
+      });
+    } catch (error) {
+      console.error('Failed to refresh lobby message:', error);
+    }
+  }
+
+  async handleLobbyButton(interaction, { action, gameId }) {
+    if (!this.discordGames || !this.discordGames.has(gameId)) {
+      await interaction.reply({ content: '❌ This lobby no longer exists (bot may have restarted). Create a new game with `/create-game`.', ephemeral: true });
+      return;
+    }
+
+    const game = this.discordGames.get(gameId);
+
+    if (action === 'join') {
+      if (game.status !== 'waiting') {
+        await interaction.reply({ content: '⚠️ This game already started.', ephemeral: true });
+        return;
+      }
+      if (game.players.some((p) => p.id === interaction.user.id)) {
+        await interaction.reply({ content: '✅ You are already in this lobby.', ephemeral: true });
+        return;
+      }
+      if (game.players.length >= game.maxPlayers) {
+        await interaction.reply({ content: '❌ Lobby is full.', ephemeral: true });
+        return;
+      }
+      game.players.push({
+        id: interaction.user.id,
+        username: interaction.user.username,
+        discriminator: interaction.user.discriminator || '0000',
+        avatar: interaction.user.avatar,
+        isDiscordBot: true,
+      });
+      await this.refreshLobbyMessage(game);
+      this.emitSpectator(game.channelId, 'lobby_update', game);
+      await interaction.reply({ content: `✅ Joined lobby \`${game.id}\`.`, ephemeral: true });
+      return;
+    }
+
+    if (action === 'leave') {
+      if (game.status !== 'waiting') {
+        await interaction.reply({ content: '⚠️ Cannot leave after the game started.', ephemeral: true });
+        return;
+      }
+      if (game.creator.id === interaction.user.id) {
+        await interaction.reply({ content: '❌ Host cannot leave. Start the game or abandon by creating a new one.', ephemeral: true });
+        return;
+      }
+      const before = game.players.length;
+      game.players = game.players.filter((p) => p.id !== interaction.user.id);
+      if (game.players.length === before) {
+        await interaction.reply({ content: 'You are not in this lobby.', ephemeral: true });
+        return;
+      }
+      await this.refreshLobbyMessage(game);
+      this.emitSpectator(game.channelId, 'lobby_update', game);
+      await interaction.reply({ content: '👋 Left the lobby.', ephemeral: true });
+      return;
+    }
+
+    if (action === 'start') {
+      if (game.creator.id !== interaction.user.id) {
+        await interaction.reply({ content: '❌ Only the host can start the game.', ephemeral: true });
+        return;
+      }
+      if (game.status !== 'waiting') {
+        await interaction.reply({ content: '⚠️ Game already started.', ephemeral: true });
+        return;
+      }
+      if (game.players.length < 3) {
+        await interaction.reply({ content: '❌ Need at least 3 players to start.', ephemeral: true });
+        return;
+      }
+
+      game.status = 'playing';
+      game.currentRound = 1;
+      await this.refreshLobbyMessage(game);
+
+      const embed = new EmbedBuilder()
+        .setColor(0x00FF00)
+        .setTitle('🚀 Game Started!')
+        .setDescription(`${this.formatGameType(game.type)} is now beginning!`)
+        .addFields(
+          { name: 'Players', value: game.players.map((p) => `• ${p.username}`).join('\n'), inline: false },
+          { name: 'Round', value: '1', inline: true },
+        )
+        .setTimestamp();
+
+      await interaction.reply({ embeds: [embed] });
+      this.emitSpectator(game.channelId, 'game_start', game);
+      postGameStarted({
+        guildId: interaction.guildId || game.guildId,
+        channelId: game.channelId,
+        gameType: game.type,
+        players: game.players.length,
+      });
+
+      if (game.type === 'degens-against-decency') {
+        await this.startDegensDiscordGame(game);
+      } else {
+        // MVP: only Degens should reach here via default create; keep slash /start-game for other types
+        await interaction.followUp({ content: 'Use `/start-game` for non-Degens types (deferred in MVP).', ephemeral: true }).catch(() => {});
+      }
+      return;
+    }
+
+    await interaction.reply({ content: 'Unknown lobby action.', ephemeral: true });
+  }
+
   // Command Handlers
   async handleCreateGame(interaction) {
-    const gameType = interaction.options.getString('type');
+    const gameType = interaction.options.getString('type') || 'degens-against-decency';
+    if (gameType === 'poker' || gameType === '2-truths-and-a-lie') {
+      await interaction.reply({
+        content: '⏳ Poker and 2 Truths are deferred for the channel MVP. Create a Degens Against Decency lobby (omit type or pick Degens).',
+        ephemeral: true,
+      });
+      return;
+    }
     const maxPlayers = interaction.options.getInteger('max-players') || 7;
     const isPrivate = interaction.options.getBoolean('private') || false;
 
@@ -429,25 +565,29 @@ class DiscordBot {
 
     await interaction.reply({ embeds: [embed] });
 
-    // Update the original game message if possible
-    try {
-      const channel = await this.client.channels.fetch(game.channelId);
-      if (channel && game.joinMessageId) {
-        const message = await channel.messages.fetch(game.joinMessageId);
-        const updatedEmbed = new EmbedBuilder()
-          .setColor(0x57F287)
-          .setTitle('🎯 How to Join')
-          .setDescription('Players can join this game using:')
-          .addFields(
-            { name: 'Command', value: `/join-game ${gameId}`, inline: false },
-            { name: 'Current Players', value: `${game.players.length}/${game.maxPlayers}`, inline: false },
-            { name: 'Players', value: game.players.map(p => `• ${p.username}`).join('\n'), inline: false }
-          );
+    // Update the lobby message (preferred) or fall back to the legacy join message
+    if (game.lobbyMessageId) {
+      await this.refreshLobbyMessage(game);
+    } else {
+      try {
+        const channel = await this.client.channels.fetch(game.channelId);
+        if (channel && game.joinMessageId) {
+          const message = await channel.messages.fetch(game.joinMessageId);
+          const updatedEmbed = new EmbedBuilder()
+            .setColor(0x57F287)
+            .setTitle('🎯 How to Join')
+            .setDescription('Players can join this game using:')
+            .addFields(
+              { name: 'Command', value: `/join-game ${gameId}`, inline: false },
+              { name: 'Current Players', value: `${game.players.length}/${game.maxPlayers}`, inline: false },
+              { name: 'Players', value: game.players.map(p => `• ${p.username}`).join('\n'), inline: false }
+            );
 
-        await message.edit({ embeds: [updatedEmbed] });
+          await message.edit({ embeds: [updatedEmbed] });
+        }
+      } catch (error) {
+        console.error('Failed to update join message:', error);
       }
-    } catch (error) {
-      console.error('Failed to update join message:', error);
     }
 
     // Check if game is ready to start
@@ -1217,6 +1357,13 @@ class DiscordBot {
     
     game.status = 'finished';
     this.emitSpectator(game.channelId, 'game_end', game);
+    postGameEnded({
+      guildId: game.guildId,
+      channelId: game.channelId,
+      gameType: game.type,
+      winnerTag: winner?.username || '?',
+      players: game.players.length,
+    });
     setTimeout(() => {
       this.discordGames.delete(game.id);
     }, 300000);

--- a/src/ops.js
+++ b/src/ops.js
@@ -117,6 +117,30 @@ function postAnalytics({ event, title, description, fields = [], color }) {
   }));
 }
 
+function postSupport({ type, user, guild, details }) {
+  const typeLabel = {
+    bug_report: '🐛 Bug report',
+    suggestion: '💡 Suggestion',
+    say_hi: '👋 Say hi',
+    donate: '☕ Donate',
+  }[type] || type;
+
+  postOps('support', () => ({
+    embeds: [
+      new EmbedBuilder()
+        .setColor(COLORS.support)
+        .setTitle(typeLabel)
+        .setDescription(details ? truncate(details, 1500) : '_No details_')
+        .addFields(
+          { name: 'User', value: `${user?.tag || '?'} (<@${user?.id}>)`, inline: true },
+          { name: 'Guild', value: guild ? `${guild.name}\n\`${guild.id}\`` : 'DM / unknown', inline: true },
+        )
+        .setFooter({ text: `${botId()} · /support` })
+        .setTimestamp(),
+    ],
+  }));
+}
+
 function postGuildInstall(guild) {
   postAnalytics({
     event: 'guild_install',
@@ -143,10 +167,26 @@ function postGameStarted({ guildId, channelId, gameType, players }) {
   });
 }
 
+function postGameEnded({ guildId, channelId, gameType, winnerTag, players }) {
+  postAnalytics({
+    event: 'game_ended',
+    title: '🏆 Game ended',
+    fields: [
+      { name: 'Type', value: gameType || '?', inline: true },
+      { name: 'Winner', value: winnerTag || '?', inline: true },
+      { name: 'Players', value: String(players ?? '?'), inline: true },
+      { name: 'Guild', value: `\`${guildId || '?'}\``, inline: true },
+      channelId ? { name: 'Channel', value: `<#${channelId}>`, inline: true } : null,
+    ],
+  });
+}
+
 module.exports = {
   initOps,
   postError,
   postGuildInstall,
   postGameStarted,
+  postGameEnded,
   postAnalytics,
+  postSupport,
 };


### PR DESCRIPTION
## Summary
- Channel-first lobby UX: `/create-game` defaults to Degens with Join / Leave / Start buttons; Activity "Open Retro View" CTA removed
- Ops: `postSupport` + `postGameEnded`; `/support` and `/help` slash commands registered (Entry Point preserved)
- Document in-memory lobby restart limit; Poker / 2 Truths deferred for MVP

## Test plan
- [ ] `/help` shows channel play guide
- [ ] `/create-game` (no type) → lobby embed with Join / Leave / Start, no Activity link
- [ ] Join / Leave / Start buttons work (host-only Start, min 3 players)
- [ ] `/support` lands in ops support channel
- [ ] Health: `curl -s https://degensagainstdecency.fly.dev/api/health` → `discordBot: true`
- [ ] Confirm `/launch` Entry Point still present after `npm run deploy-commands`

Note: Already deployed to Fly from this branch for soft-launch smoke.